### PR TITLE
Revert erroneous changes from FIR pull req

### DIFF
--- a/firmware/ip/axis_signal_gen_v6/src/verilog/axi_slv_sg_v6_sv.sv
+++ b/firmware/ip/axis_signal_gen_v6/src/verilog/axi_slv_sg_v6_sv.sv
@@ -129,8 +129,9 @@ module axi_slv_sg_v6_sv #(parameter DATA_WIDTH = 32, parameter ADDR_WIDTH = 6)(
     // Implement memory mapped register select and write logic generation
     assign slv_reg_wren = axi_wready && wvalid && axi_awready && awvalid;
 
-    always_ff@(posedge aclk) begin : decoding_regs_aclk
-        logic [OPT_MEM_ADDR_BITS:0] loc_addr;
+    logic [OPT_MEM_ADDR_BITS:0] loc_addr;
+    assign loc_addr = axi_awaddr[(ADDR_LSB + OPT_MEM_ADDR_BITS):ADDR_LSB];
+    always_ff @(posedge aclk) begin : decoding_regs_aclk
         if (~aresetn) begin 
             slv_reg0 <= 0;
             slv_reg1 <= 0;
@@ -149,28 +150,8 @@ module axi_slv_sg_v6_sv #(parameter DATA_WIDTH = 32, parameter ADDR_WIDTH = 6)(
             slv_reg14 <= 0;
             slv_reg15 <= 0;
         end else begin 
-            /*
-            loc_addr <= axi_awaddr[(ADDR_LSB + OPT_MEM_ADDR_BITS):ADDR_LSB];
-
-            if (slv_reg_wren) begin 
+            if (slv_reg_wren) begin
                 case (loc_addr)
-            */
-            
-            // Replace or augment the code inside the decoding always_ff
-            logic [OPT_MEM_ADDR_BITS:0] write_addr;
-
-            // keep existing capture of axi_awaddr:
-            loc_addr <= axi_awaddr[(ADDR_LSB + OPT_MEM_ADDR_BITS):ADDR_LSB];
-
-            // compute write_addr using incoming awaddr if we're writing in this same cycle
-            if (slv_reg_wren) begin
-                write_addr = awaddr[(ADDR_LSB + OPT_MEM_ADDR_BITS) : ADDR_LSB];
-            end else begin
-                write_addr = loc_addr;
-            end
-
-            if (slv_reg_wren) begin
-                case (write_addr)
                     'b0000: begin
                            for (int byte_index = 0; byte_index < (DATA_WIDTH/8); byte_index++) begin
                              if (wstrb[byte_index]) begin
@@ -335,6 +316,40 @@ module axi_slv_sg_v6_sv #(parameter DATA_WIDTH = 32, parameter ADDR_WIDTH = 6)(
             end
         end
     end
+
+
+    /* AI CODE UNTESTED 
+
+    // Signal to capture the completion of the write transaction
+    logic write_transaction_completed;
+
+    // Combinational logic to detect write transaction completion
+    assign write_transaction_completed = axi_awready && awvalid && axi_wready && wvalid;
+
+    // Implement write response logic generation
+    always_ff@(posedge aclk) begin 
+        if (~aresetn) begin 
+            axi_bvalid <= 0;
+            axi_bresp <= 2'b00; // Assuming OKAY response
+        end else begin 
+            if (write_transaction_completed) begin 
+                // Assert bvalid one cycle after the transaction completes
+                axi_bvalid <= 1;
+                axi_bresp <= 2'b00;
+            end else if (bready == 1 && axi_bvalid == 1) begin 
+                // Deassert bvalid when master is ready to receive the response
+                axi_bvalid <= 0;
+            end
+        end
+    end
+*/
+
+// always @(posedge aclk) begin
+//     $display("%0t AWV=%b AWREADY=%b WVAL=%b WREADY=%b slv_reg1=%0h START_ADDR_REG=%0h",
+//              $time, awvalid, awready, wvalid, wready, slv_reg1, START_ADDR_REG);
+// end
+
+    /* END AI CODE */
 
     // Implement axi_arready generation
     always_ff@(posedge aclk) begin 

--- a/firmware/ip/axis_signal_gen_v6/tb/Makefile
+++ b/firmware/ip/axis_signal_gen_v6/tb/Makefile
@@ -28,7 +28,7 @@ sim:
 	./$(OBJ_DIR)/V$(TOP_MODULE)
 
 verilate: 
-	~/Downloads/oss-cad-suite-linux-x64-20260324/oss-cad-suite/bin/verilator $(VERILATOR_FLAGS) --top-module $(TOP_MODULE) $(VERILOG_SOURCES)
+	verilator $(VERILATOR_FLAGS) --top-module $(TOP_MODULE) $(VERILOG_SOURCES)
 
 clean:
 	rm -rf $(OBJ_DIR)


### PR DESCRIPTION
FIR pull request #60 contained a couple changes that I did not catch before merging. The makefile had the path to verilator hardcoded and it seems that the axi slave module was reverted to an earlier version (before Diego's code cleanup). 

In the future lets make sure to have multiple smaller PRs to ensure that things like this don't slip though the cracks, and to allow things that are WIP to remain so without holding up other parts of the project by being tied to things that are ready in the same PR