### PR TITLE
using our dac_adc_loopback module

### DIFF
--- a/emulator/models/dac_adc/adc.sv
+++ b/emulator/models/dac_adc/adc.sv
@@ -16,23 +16,20 @@ module adc_model #(
     int digital_out_reg;
 
     initial begin
-        quantization_step = (2.0 * V_REF) / (1 << BITS);
+      // full range is (-2^(BITS-1) to 2^(BITS-1)-1)
+        quantization_step = V_REF / (1 << (BITS - 1));
     end
 
     // Behavioral model of ADC
     always @(negedge clk) begin
 
-        // Scale input to a value between 0 and (2^BITS - 1)
-        scaled_input = analog_in + V_REF;
+        digital_out_reg = $rtoi(analog_in / quantization_step);
 
-        // Quantize value to the nearest integer
-        digital_out_reg = $rtoi(scaled_input / quantization_step);
-
-        // Clip result to ensure it stays within: 0 to 2^BITS - 1
-        if (digital_out_reg >= (1 << BITS)) begin
-            digital_out_reg = (1 << BITS) - 1;
-        end else if (digital_out_reg < 0) begin
-            digital_out_reg = 0;
+        // Clip result to ensure it stays within signed 2's complement
+        if (digital_out_reg >= (1 << (BITS - 1))) begin
+            digital_out_reg = (1 << (BITS - 1)) - 1;
+        end else if (digital_out_reg < -(1 << (BITS - 1))) begin
+            digital_out_reg = -(1 << (BITS - 1));
         end
 
         // Output signal

--- a/emulator/models/dac_adc/dac_adc_top.sv
+++ b/emulator/models/dac_adc/dac_adc_top.sv
@@ -4,7 +4,9 @@
 // the DAC and ADC, so it is not 100 percent accurate.
 
 module dac_adc_loop #(
-    parameter integer BITS = 16,
+    parameter integer DAC_BITS = 16,
+    parameter integer ADC_BITS = 16,
+    parameter integer OUT_BITS = 16,
     parameter real V_REF = 1.0,
     parameter integer N_DAC = 16,
     parameter integer N_ADC = 8,
@@ -16,16 +18,16 @@ module dac_adc_loop #(
     input  logic        dac_fs_clk,
     input  logic        adc_fs_clk,
 
-    input  logic [N_DAC*BITS-1:0] s_axis_tdata,
+    input  logic [N_DAC*DAC_BITS-1:0] s_axis_tdata,
     input  logic                  s_axis_tvalid,
-    output logic [N_ADC*BITS-1:0] m_axis_tdata,
+    output logic [N_ADC*OUT_BITS-1:0] m_axis_tdata,
     output logic                  m_axis_tvalid
 );
 
     // Internal Signals
-    reg [N_DAC*BITS-1:0]      dac_data_latched;
+    reg [N_DAC*DAC_BITS-1:0]      dac_data_latched;
     logic [$clog2(N_DAC)-1:0] dac_samp_cnt = 0;
-    logic [BITS-1:0]          dac_serial_data;
+    logic [DAC_BITS-1:0]          dac_serial_data;
     logic                     dac_serial_valid;
     real                      dac_out;
 
@@ -42,13 +44,14 @@ module dac_adc_loop #(
     int  idx_prev;
     real t1, t2, y1, y2;
 
-    logic [BITS-1:0]          adc_serial_out;
-    logic [N_ADC*BITS-1:0]    adc_shift_reg;
+    logic [ADC_BITS-1:0]          adc_serial_out;
+    logic [N_ADC*OUT_BITS-1:0]    adc_shift_reg;
     logic [$clog2(N_ADC)-1:0] adc_samp_cnt = 0;
+    logic                     adc_ready;
 
     // DAC model
     dac #(
-        .BITS(BITS),
+        .BITS(DAC_BITS),
         .V_REF(V_REF)
     ) dac_inst (
         .clk(dac_fs_clk),
@@ -59,7 +62,7 @@ module dac_adc_loop #(
 
     // ADC model
     adc_model #(
-        .BITS(BITS),
+        .BITS(ADC_BITS),
         .V_REF(V_REF)
     ) adc_inst (
         .clk(adc_fs_clk),
@@ -85,13 +88,13 @@ module dac_adc_loop #(
                 dac_data_latched <= 0;
 
             if (s_axis_tvalid)
-                dac_serial_data <= s_axis_tdata[0 +: BITS];
+                dac_serial_data <= s_axis_tdata[0 +: DAC_BITS];
             else
                 dac_serial_data <= 0;
 
             dac_samp_cnt <= 1;
         end else begin
-            dac_serial_data <= dac_data_latched[BITS*dac_samp_cnt +: BITS];
+            dac_serial_data <= dac_data_latched[DAC_BITS*dac_samp_cnt +: DAC_BITS];
             if (dac_samp_cnt == N_DAC - 1) dac_samp_cnt <= 0;
             else                           dac_samp_cnt <= dac_samp_cnt + 1;
         end
@@ -140,20 +143,28 @@ module dac_adc_loop #(
     end
     wire adc_clk_rise = adc_clk && !adc_clk_d;
 
-    // Deserialize ADC samples in adc_clk domain
+    logic signed [OUT_BITS-1:0] adc_padded_out;
+    assign adc_padded_out = $signed(adc_serial_out);
+    logic [N_ADC*OUT_BITS-1:0]    adc_out_reg;
+
+    // Deserialize ADC samples in adc_fs_clk domain
     always @(posedge adc_fs_clk) begin
         if (adc_clk_rise) begin
+            // Register from the last 8 cycles
+            adc_out_reg <= adc_shift_reg;
+            
+            // Start capturing the new word's first sample
             adc_samp_cnt <= 1;
-            adc_shift_reg[0 +: BITS] <= adc_serial_out;
+            adc_shift_reg[0 +: OUT_BITS] <= adc_padded_out;
         end else begin
-            adc_shift_reg[BITS*adc_samp_cnt +: BITS] <= adc_serial_out;
+            adc_shift_reg[OUT_BITS*adc_samp_cnt +: OUT_BITS] <= adc_padded_out;
             if (adc_samp_cnt == N_ADC - 1) adc_samp_cnt <= 0;
             else                           adc_samp_cnt <= adc_samp_cnt + 1;
         end
     end
 
     always @(posedge adc_clk) begin
-        m_axis_tdata  <= adc_shift_reg;
+        m_axis_tdata  <= adc_out_reg;
         m_axis_tvalid <= 1'b1;
     end
 

--- a/firmware/testbench/qick_testbench/src/tb/tb_qick_verilator.sv
+++ b/firmware/testbench/qick_testbench/src/tb/tb_qick_verilator.sv
@@ -978,57 +978,80 @@ reg qcom_rdy_i, qp2_rdy_i;
    // TODO: RF DATA CONVERTER IP
    //--------------------------------------
 
-   localparam DAC_W = 16;
-   logic signed [DAC_W-1:0] dac_data;
-   localparam ADC_W = 14;
-   logic signed [ADC_W-1:0] adc_sample;
-   logic signed [15:0] adc_data;
+   // <<<<<<<<<<<< OLD DAC AND ADC MODEL
+   // localparam DAC_W = 16;
+   // logic signed [DAC_W-1:0] dac_data;
+   // localparam ADC_W = 14;
+   // logic signed [ADC_W-1:0] adc_sample;
+   // logic signed [15:0] adc_data;
 
-   model_DAC_ADC #(
-      .DAC_W               (DAC_W),
-      .ADC_W               (ADC_W),
-      .BUFFER_SIZE         (16)
-   ) u_model_DAC_ADC (
-      .clk_DAC             (dac_fs),
-      .dac_sample          (dac_data),
+   // model_DAC_ADC #(
+   //    .DAC_W               (DAC_W),
+   //    .ADC_W               (ADC_W),
+   //    .BUFFER_SIZE         (16)
+   // ) u_model_DAC_ADC (
+   //    .clk_DAC             (dac_fs),
+   //    .dac_sample          (dac_data),
 
-      .clk_ADC             (adc_fs),
-      .adc_sample          (adc_sample),
+   //    .clk_ADC             (adc_fs),
+   //    .adc_sample          (adc_sample),
 
-      .mode                (1)   // 0 = ZOH, 1 = linear
-   );
+   //    .mode                (1)   // 0 = ZOH, 1 = linear
+   // );
 
-   assign adc_data = $signed(adc_sample);
+   // assign adc_data = $signed(adc_sample);
 
-   logic [$clog2(N_DDS)-1:0] dac_samp_cnt;
-   always @(posedge dac_fs) begin
-      if (axis_sg_dac_tvalid) begin
-         dac_data       <= axis_sg_dac_tdata[ 16*dac_samp_cnt +: 16];
-         dac_samp_cnt   <= dac_samp_cnt + 'd1;
-      end
-      else begin
-         dac_data       <= 'd0;
-         dac_samp_cnt   <= 'd0;
-      end
-   end
+   // logic [$clog2(N_DDS)-1:0] dac_samp_cnt;
+   // always @(posedge dac_fs) begin
+   //    if (axis_sg_dac_tvalid) begin
+   //       dac_data       <= axis_sg_dac_tdata[ 16*dac_samp_cnt +: 16];
+   //       dac_samp_cnt   <= dac_samp_cnt + 'd1;
+   //    end
+   //    else begin
+   //       dac_data       <= 'd0;
+   //       dac_samp_cnt   <= 'd0;
+   //    end
+   // end
 
    // SG to DAC RF processes 16 samples per clock
    // ADC RF to RO processes 8 samples per clock
 
    assign axis_sg_dac_tready        = 1'b1;  // DAC always ready to receive samples
 
-   logic [$clog2(N_DDS)-1:0] adc_samp_cnt;
-   always @(posedge adc_fs) begin
-      if (adc_samp_cnt < 7) begin
-         adc_samp_cnt      <= adc_samp_cnt + 1;
-         rf_signal_valid   <= 0;
-      end
-      else begin
-         adc_samp_cnt      <= 0;
-         rf_signal_valid   <= 1;
-      end
-      rf_signal_data[16*adc_samp_cnt +: 16] <= adc_data;
-   end
+   // logic [$clog2(N_DDS)-1:0] adc_samp_cnt;
+   // always @(posedge adc_fs) begin
+   //    if (adc_samp_cnt < 7) begin
+   //       adc_samp_cnt      <= adc_samp_cnt + 1;
+   //       rf_signal_valid   <= 0;
+   //    end
+   //    else begin
+   //       adc_samp_cnt      <= 0;
+   //       rf_signal_valid   <= 1;
+   //    end
+   //    rf_signal_data[16*adc_samp_cnt +: 16] <= adc_data;
+   // end
+
+   // ============
+   dac_adc_loop #(
+      .DAC_BITS            (16),
+      .ADC_BITS            (14),
+      .OUT_BITS            (16),
+      .N_DAC               (N_DDS),
+      .N_ADC               (8),
+      .BUFFER_SIZE         (16),
+      .USE_INTERPOLATION   (0)     // 0 = ZOH, 1 = linear
+   ) u_dac_adc_loop (
+      .dac_clk             (sg_clk),             // Slow DAC clock
+      .adc_clk             (ro_clk),             // Slow ADC clock
+      .dac_fs_clk          (dac_fs),             // Fast sample DAC clock
+      .adc_fs_clk          (adc_fs),             // Fast sample ADC clock
+
+      .s_axis_tdata        (axis_sg_dac_tdata),  // data from SG
+      .s_axis_tvalid       (axis_sg_dac_tvalid), 
+      .m_axis_tdata        (rf_signal_data),     // data to RO
+      .m_axis_tvalid       (rf_signal_valid)
+   // );
+   // >>>>>>>>>>>> NEW DAC AND ADC LOOPBACK
 
    // Model Transport delay
    // NOTE: THESE MUST BE REG TO WORK!!!


### PR DESCRIPTION
To see the same waveforms that we have been looking at, we need to look at internal signals within the dac_adc submodule:

- adc_padded_out[15:0]
- dac_serial_data[15:0]
